### PR TITLE
Correct package.json main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jsref",
   "version": "1.2.0",
   "description": "Ultra light json-ref resolver for browser and node. Supports local, external and custom refs in under 1.5b",
-  "main": "index.js",
+  "main": "jsref.js",
   "scripts": {
     "test": "test.js"
   },


### PR DESCRIPTION
Fixes the `package.json` file to point to `jsref.js` instead of the non-existent `index.js`.